### PR TITLE
Separate History

### DIFF
--- a/history/junitPlugin.json
+++ b/history/junitPlugin.json
@@ -1,0 +1,11 @@
+[
+    {
+        "semver": "0.0.30",
+        "date": "2019-05-16",
+        "image": "urbancode/ucv-ext-junit:0.0.30",
+        "notes": [
+            "Initial release of the JUnit plugin.",
+            "Runs JUnit parser in container."
+        ]
+    }
+]

--- a/index.json
+++ b/index.json
@@ -7,16 +7,14 @@
             "name": "UrbanCode",
             "email": "urbancode-plugins@hcl.com"
         },
-        "versions": [
-            {
-                "semver": "0.0.30",
-                "date": "2019-05-16",
-                "image": "urbancode/ucv-ext-junit:0.0.30",
-                "notes": [
-                    "Initial release of the JUnit plugin.",
-                    "Runs JUnit parser in container."
-                ]
-            }
-        ]
+        "current": {
+            "semver": "0.0.30",
+            "date": "2019-05-16",
+            "image": "urbancode/ucv-ext-junit:0.0.30",
+            "notes": [
+                "Initial release of the JUnit plugin.",
+                "Runs JUnit parser in container."
+            ]
+        }
     }
 }


### PR DESCRIPTION
Separate the history (past versions) of a plugin from the main index to keep main index file size down.